### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 This my resume in markdown format which lets me version, style and generate html and pdf formats using https://github.com/c0bra/markdown-resume-js. The current style supports printing and mobile devices.
 
-##setup
+## setup
 * first: npm install (which installs [markdown-resume](https://github.com/there4/markdown-resume))
 * second: remove the existing core css files in `node_modules/markdown-resume/assets/css` and move `resume.css` into that dir.
 
 
 __to generate PDF's you'll also need to install: [wkhtmltopdf](https://github.com/pdfkit/pdfkit/wiki/Installing-WKHTMLTOPDF)__.
 
-##generate
+## generate
 ```shell
 node node_modules/markdown-resume/bin/md2resume resume.md
 node node_modules/markdown-resume/bin/md2resume --pdf resume.md


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
